### PR TITLE
Add external audio file storage module

### DIFF
--- a/app/src/main/java/com/sun/japaneselisteningtrainer/data/AppContainer.kt
+++ b/app/src/main/java/com/sun/japaneselisteningtrainer/data/AppContainer.kt
@@ -8,6 +8,8 @@ import com.sun.japaneselisteningtrainer.data.repository.local.JLTDbHelper
 import com.sun.japaneselisteningtrainer.data.repository.local.LocalAudioRepository
 import com.sun.japaneselisteningtrainer.data.repository.local.LocalFolderRepository
 import com.sun.japaneselisteningtrainer.data.repository.mock.MockAudioRepository
+import com.sun.japaneselisteningtrainer.data.storage.AudioFileStorage
+import com.sun.japaneselisteningtrainer.data.storage.ExternalAudioFileStorage
 
 
 /**
@@ -16,6 +18,7 @@ import com.sun.japaneselisteningtrainer.data.repository.mock.MockAudioRepository
 interface AppContainer {
     val audioRepository: AudioRepository
     val folderRepository: FolderRepository
+    val audioFileStorage: AudioFileStorage
 }
 
 /**
@@ -30,6 +33,7 @@ class MockAppDataContainer(private val context: Context) : AppContainer {
      * Implementation for [FolderRepository]
      */
     override val folderRepository: FolderRepository = MockFolderRepository()
+    override val audioFileStorage: AudioFileStorage = ExternalAudioFileStorage(context)
 }
 
 class AppDataContainer(private val context: Context) : AppContainer {
@@ -45,5 +49,8 @@ class AppDataContainer(private val context: Context) : AppContainer {
      */
     override val folderRepository: FolderRepository by lazy {
         LocalFolderRepository(JLTDbHelper(context))
+    }
+    override val audioFileStorage: AudioFileStorage by lazy {
+        ExternalAudioFileStorage(context)
     }
 }

--- a/app/src/main/java/com/sun/japaneselisteningtrainer/data/storage/AudioFileStorage.kt
+++ b/app/src/main/java/com/sun/japaneselisteningtrainer/data/storage/AudioFileStorage.kt
@@ -1,0 +1,74 @@
+package com.sun.japaneselisteningtrainer.data.storage
+
+import android.content.Context
+import android.os.Environment
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Provides CRUD operations for audio files stored in the app specific external storage.
+ */
+interface AudioFileStorage {
+    /**
+     * Save audio file [fileName] from [input] into storage.
+     * Returns the written [File].
+     */
+    suspend fun create(fileName: String, input: InputStream): File
+
+    /**
+     * Return [File] for [fileName] if it exists.
+     */
+    suspend fun read(fileName: String): File?
+
+    /**
+     * Replace content of [fileName] with data from [input].
+     * Returns the updated [File].
+     */
+    suspend fun update(fileName: String, input: InputStream): File
+
+    /**
+     * Delete stored file [fileName]. Returns true if deletion was successful.
+     */
+    suspend fun delete(fileName: String): Boolean
+}
+
+/**
+ * Implementation of [AudioFileStorage] using app-specific external storage.
+ */
+class ExternalAudioFileStorage(private val context: Context) : AudioFileStorage {
+
+    private val audioDir: File by lazy {
+        context.getExternalFilesDir(Environment.DIRECTORY_MUSIC)!!.apply {
+            if (!exists()) {
+                mkdirs()
+            }
+        }
+    }
+
+    override suspend fun create(fileName: String, input: InputStream): File =
+        withContext(Dispatchers.IO) {
+            val file = File(audioDir, fileName)
+            file.outputStream().use { output -> input.copyTo(output) }
+            return@withContext file
+        }
+
+    override suspend fun read(fileName: String): File? = withContext(Dispatchers.IO) {
+        val file = File(audioDir, fileName)
+        return@withContext if (file.exists()) file else null
+    }
+
+    override suspend fun update(fileName: String, input: InputStream): File =
+        withContext(Dispatchers.IO) {
+            val file = File(audioDir, fileName)
+            file.outputStream().use { output -> input.copyTo(output) }
+            return@withContext file
+        }
+
+    override suspend fun delete(fileName: String): Boolean = withContext(Dispatchers.IO) {
+        val file = File(audioDir, fileName)
+        return@withContext file.delete()
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `AudioFileStorage` interface and `ExternalAudioFileStorage` to manage audio files in app-specific external storage
- expose the new storage module through `AppContainer` for dependency injection

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68998d150cfc833296ad29eab06e05f7