### PR TITLE
feat: add audio search screen

### DIFF
--- a/app/src/main/java/com/sun/japaneselisteningtrainer/ui/AppViewModelProvider.kt
+++ b/app/src/main/java/com/sun/japaneselisteningtrainer/ui/AppViewModelProvider.kt
@@ -33,6 +33,7 @@ import com.sun.japaneselisteningtrainer.ui.folder.create.CreateFolderViewModel
 import com.sun.japaneselisteningtrainer.ui.folder.edit.EditFolderViewModel
 import com.sun.japaneselisteningtrainer.ui.home.HomeViewModel
 import com.sun.japaneselisteningtrainer.ui.miniaudio.MiniAudioPlayerViewModel
+import com.sun.japaneselisteningtrainer.ui.search.SearchViewModel
 
 /**
  * Provides Factory to create instance of ViewModel for the entire Japanese Listening Trainer app
@@ -42,6 +43,14 @@ object AppViewModelProvider {
         // Initializer for HomeViewModel
         initializer {
             HomeViewModel(
+                audioRepository = trainerApplication().container.audioRepository,
+                audioServiceManager = trainerApplication().container.audioServiceManager
+            )
+        }
+
+        // Initializer for SearchViewModel
+        initializer {
+            SearchViewModel(
                 audioRepository = trainerApplication().container.audioRepository,
                 audioServiceManager = trainerApplication().container.audioServiceManager
             )

--- a/app/src/main/java/com/sun/japaneselisteningtrainer/ui/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/sun/japaneselisteningtrainer/ui/navigation/NavigationGraph.kt
@@ -71,6 +71,8 @@ import com.sun.japaneselisteningtrainer.ui.home.HomeDestination
 import com.sun.japaneselisteningtrainer.ui.home.HomeScreen
 import com.sun.japaneselisteningtrainer.ui.miniaudio.MiniAudioPlayer
 import com.sun.japaneselisteningtrainer.ui.miniaudio.MiniAudioPlayerViewModel
+import com.sun.japaneselisteningtrainer.ui.search.SearchDestination
+import com.sun.japaneselisteningtrainer.ui.search.SearchScreen
 import com.sun.japaneselisteningtrainer.ui.navigation.NavItem.Add
 import com.sun.japaneselisteningtrainer.ui.navigation.NavItem.Companion.destinationRoutes
 import com.sun.japaneselisteningtrainer.ui.navigation.NavItem.Companion.items
@@ -82,7 +84,7 @@ sealed class NavItem(
     object Home : NavItem(Icons.Default.Home, HomeDestination)
     object Folder : NavItem(Icons.Default.Menu, FolderListDestination)
     object Add : NavItem(Icons.Default.Add, AudioEntryDestination)
-    object Search : NavItem(Icons.Default.Search, null)
+    object Search : NavItem(Icons.Default.Search, SearchDestination)
     object Profile : NavItem(Icons.Default.Person, null)
 
     companion object {
@@ -146,6 +148,25 @@ fun TrainerNavHost(
                 },
                 navigateToFolderAudioList = { folderId ->
                     navController.navigate("${FolderAudioListDestination.route}/$folderId")
+                }
+            )
+        }
+        composable(route = SearchDestination.route) {
+            SearchScreen(
+                navigationBar = {
+                    TrainerNavigationBar(
+                        navController = navController,
+                        miniAudioPlayerViewModel = miniAudioPlayerViewModel,
+                        navigateToMusicPlayer = { audioId ->
+                            navController.navigate(MusicPlayerDestination.createRoute(audioId))
+                        }
+                    )
+                },
+                navigateToMusicPlayer = { audioId ->
+                    navController.navigate(MusicPlayerDestination.createRoute(audioId))
+                },
+                onAudioLongClick = { audioId ->
+                    navController.navigate(AudioMenuDestination.createRoute(audioId))
                 }
             )
         }

--- a/app/src/main/java/com/sun/japaneselisteningtrainer/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/sun/japaneselisteningtrainer/ui/search/SearchScreen.kt
@@ -1,0 +1,84 @@
+package com.sun.japaneselisteningtrainer.ui.search
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.sun.japaneselisteningtrainer.R
+import com.sun.japaneselisteningtrainer.ui.AppViewModelProvider
+import com.sun.japaneselisteningtrainer.ui.home.AudioCard
+import com.sun.japaneselisteningtrainer.ui.navigation.NavigationDestination
+
+object SearchDestination : NavigationDestination {
+    override val route: String = "search"
+    override val titleRes: Int = R.string.search
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchScreen(
+    modifier: Modifier = Modifier,
+    viewModel: SearchViewModel = viewModel(factory = AppViewModelProvider.Factory),
+    navigationBar: @Composable () -> Unit,
+    navigateToMusicPlayer: (Int) -> Unit,
+    onAudioLongClick: (Int) -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    TextField(
+                        value = uiState.query,
+                        onValueChange = viewModel::onQueryChange,
+                        placeholder = { Text(stringResource(R.string.search)) },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                )
+            )
+        },
+        bottomBar = { navigationBar() },
+        containerColor = MaterialTheme.colorScheme.background
+    ) { paddingValues ->
+        LazyColumn(
+            contentPadding = paddingValues,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxSize()
+        ) {
+            items(uiState.audioList) { audio ->
+                AudioCard(
+                    title = audio.title,
+                    imageRes = R.drawable.logo,
+                    isFavorite = audio.isFavorite,
+                    onClick = { navigateToMusicPlayer(audio.id) },
+                    onLongClick = { onAudioLongClick(audio.id) },
+                    onFavoriteClick = { viewModel.toggleFavorite(audio.id) }
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/sun/japaneselisteningtrainer/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/sun/japaneselisteningtrainer/ui/search/SearchViewModel.kt
@@ -1,0 +1,59 @@
+package com.sun.japaneselisteningtrainer.ui.search
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sun.japaneselisteningtrainer.data.model.Audio
+import com.sun.japaneselisteningtrainer.data.repository.AudioRepository
+import com.sun.japaneselisteningtrainer.service.AudioServiceManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+
+data class SearchUiState(
+    val query: String = "",
+    val audioList: List<Audio> = emptyList()
+)
+
+class SearchViewModel(
+    private val audioRepository: AudioRepository,
+    private val audioServiceManager: AudioServiceManager
+) : ViewModel() {
+
+    private val _query = MutableStateFlow("")
+
+    val uiState: StateFlow<SearchUiState> = combine(
+        audioRepository.getAllAudioStream(),
+        _query
+    ) { audioList, query ->
+        val filtered = if (query.isBlank()) emptyList() else audioList.filter {
+            val fileName = Uri.parse(it.filePath).lastPathSegment ?: ""
+            it.title.contains(query, ignoreCase = true) ||
+                    fileName.contains(query, ignoreCase = true)
+        }
+        SearchUiState(query = query, audioList = filtered)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(TIMEOUT_MILLIS),
+        initialValue = SearchUiState()
+    )
+
+    fun onQueryChange(newQuery: String) {
+        _query.value = newQuery
+    }
+
+    fun toggleFavorite(audioId: Int) {
+        viewModelScope.launch {
+            audioServiceManager.toggleFavoriteStatus(audioId)
+        }
+    }
+
+    companion object {
+        private const val TIMEOUT_MILLIS = 5_000L
+    }
+}
+


### PR DESCRIPTION
## Summary
- add search screen and view model to query audio by title or file name
- wire search destination into navigation graph and view model provider

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68abbaeab79083328fdfc571e9db1d52